### PR TITLE
Support Qt5.15.1

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -86,7 +86,7 @@ protected:
      * @param parent The parent widget.
      * @param flags The window flags.
      */
-    explicit Core(QWidget *parent = nullptr, Qt::WindowFlags flags = {});
+    explicit Core(QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::Widget);
 
     /**
      * Returns the last error message for problems during


### PR DESCRIPTION
need use default  Qt::Widget  WindowFlags  replace {}, to support Qt5.15.1 compile done.